### PR TITLE
Set automatic versioning to ConsoleApp based on release tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,9 +43,10 @@ jobs:
         run: |
           tag=$(git describe --tags --abbrev=0)
           release_name="MagicProxyPrinter-$tag-${{ matrix.target }}"
+          version=$(echo $tag | sed -E 's/^v\.?(([0-9]+\.){0,3}[0-9]+).*/\1/')
 
           # Build everything
-          dotnet publish ConsoleApp/ConsoleApp.csproj --runtime "${{ matrix.target }}" -c Release -o "$release_name"
+          dotnet publish ConsoleApp/ConsoleApp.csproj --runtime "${{ matrix.target }}" -p:GitTagVersion=$version -c Release -o "$release_name"
 
           # Pack files
           if [ "${{ matrix.target }}" == "win-x64" ]; then

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -9,7 +9,9 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
-    <Version>2.2.1</Version>
+    <Version>$(GitTagVersion)</Version>
+    <FileVersion>$(GitTagVersion)</FileVersion>
+    <AssemblyVersion>$(GitTagVersion)</AssemblyVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
[Set automatic versioning to ConsoleApp based on release tag](https://github.com/Furrman/MagicProxyPrinter/commit/b440be1668c059248382685bc611668206d5d4aa)