### PR TITLE
Fix issues with scheme and www at the beginning of the deck-url parameter

### DIFF
--- a/Domain/Factories/ServiceFactory.cs
+++ b/Domain/Factories/ServiceFactory.cs
@@ -51,8 +51,14 @@ public class ServiceFactory(IServiceProvider serviceProvider) : IServiceFactory
     {
         try
         {
-            var uri = new Uri(url);
-            return uri.Host.ToLowerInvariant();
+            Uri uri = new(url);
+            string host = uri.Host.ToLowerInvariant();
+            if (host.StartsWith("www."))
+            {
+                host = host[4..];
+            }
+
+            return host;
         }
         catch
         {

--- a/Domain/Factories/ServiceFactory.cs
+++ b/Domain/Factories/ServiceFactory.cs
@@ -51,7 +51,15 @@ public class ServiceFactory(IServiceProvider serviceProvider) : IServiceFactory
     {
         try
         {
-            Uri uri = new(url);
+            // Try to create a Uri object; if it fails without a scheme, prepend "https://"
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+            {
+                if (!Uri.TryCreate("https://" + url, UriKind.Absolute, out uri))
+                {
+                    return string.Empty;
+                }
+            }
+            
             string host = uri.Host.ToLowerInvariant();
             if (host.StartsWith("www."))
             {

--- a/Domain/Services/ArchidektService.cs
+++ b/Domain/Services/ArchidektService.cs
@@ -54,7 +54,7 @@ public class ArchidektService(IArchidektClient archidektApiClient, ILogger<Archi
     {
         deckId = 0;
         
-        string pattern = @"^https:\/\/(www\.)?archidekt\.com\/(?:api\/decks\/(\d+)\/|decks\/(\d+)\/?)";
+        string pattern = @"^(https?:\/\/)?(www\.)?archidekt\.com\/(?:api\/decks\/(\d+)\/|decks\/(\d+)\/?)";
         Regex regex = new(pattern);
 
         Match match = regex.Match(url);

--- a/Domain/Services/EdhrecService.cs
+++ b/Domain/Services/EdhrecService.cs
@@ -118,7 +118,7 @@ public class EdhrecService(IEdhrecClient edhrecClient,
     {
         relativePath = string.Empty;
 
-        string pattern = @"^https://(www\.)?edhrec\.com/(?<relativePath>(commanders|deckpreview)/.+)$";
+        string pattern = @"^(https?:\/\/)?(www\.)?edhrec\.com/(?<relativePath>(commanders|deckpreview)/.+)$";
         Regex regex = new(pattern);
 
         Match match = regex.Match(url);

--- a/Domain/Services/MoxfieldService.cs
+++ b/Domain/Services/MoxfieldService.cs
@@ -53,13 +53,13 @@ public class MoxfieldService(IMoxfieldClient moxfieldClient, ILogger<MoxfieldSer
     public bool TryExtractDeckIdFromUrl(string url, out string deckId)
     {
         deckId = string.Empty;
-        string pattern = @"^https:\/\/(www\.)?moxfield\.com\/decks\/([\w\-._~]+)(\/|(\?.*)?)$";
+        string pattern = @"^(https?:\/\/)?(www\.)?moxfield\.com\/decks\/([\w\-._~]+)(\/|(\?.*)?)$";
         Regex regex = new(pattern);
 
         Match match = regex.Match(url);
         if (match.Success)
         {
-            deckId = match.Groups[2].Value;
+            deckId = match.Groups[3].Value;
             return true;
         }
 

--- a/UnitTests/Domain/Factories/ServiceFactoryTests.cs
+++ b/UnitTests/Domain/Factories/ServiceFactoryTests.cs
@@ -20,6 +20,8 @@ public class ServiceFactoryTests
     }
 
     [Theory]
+    [InlineData("archidekt.com/decks/123456/test")]
+    [InlineData("www.archidekt.com/decks/123456/test")]
     [InlineData("https://archidekt.com/decks/123456/test")]
     [InlineData("https://www.archidekt.com/decks/123456/test")]
     public void GetDeckRetriever_WithArchidektUrl_ReturnsArchidektServiceObject(string deckUrl)
@@ -37,6 +39,8 @@ public class ServiceFactoryTests
     }
 
     [Theory]
+    [InlineData("edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
+    [InlineData("www.edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
     [InlineData("https://edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
     [InlineData("https://www.edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
     public void GetDeckRetriever_WithEdhrecUrl_ReturnsEdhrecServiceObject(string deckUrl)
@@ -54,6 +58,8 @@ public class ServiceFactoryTests
     }
 
     [Theory]
+    [InlineData("moxfield.com/decks/123456/test")]
+    [InlineData("www.moxfield.com/decks/123456/test")]
     [InlineData("https://moxfield.com/decks/123456/test")]
     [InlineData("https://www.moxfield.com/decks/123456/test")]
     public void GetDeckRetriever_WithMoxfieldUrl_ReturnsMoxfieldServiceObject(string deckUrl)

--- a/UnitTests/Domain/Factories/ServiceFactoryTests.cs
+++ b/UnitTests/Domain/Factories/ServiceFactoryTests.cs
@@ -19,11 +19,12 @@ public class ServiceFactoryTests
         );
     }
 
-    [Fact]
-    public void GetDeckRetriever_WithArchidektUrl_ReturnsArchidektServiceObject()
+    [Theory]
+    [InlineData("https://archidekt.com/decks/123456/test")]
+    [InlineData("https://www.archidekt.com/decks/123456/test")]
+    public void GetDeckRetriever_WithArchidektUrl_ReturnsArchidektServiceObject(string deckUrl)
     {
         // Arrange
-        string deckUrl = "https://archidekt.com/decks/123456/test";
         _serviceProviderMock.Setup(x => x.GetService(typeof(IArchidektService)))
             .Returns(new Mock<IArchidektService>().Object);
 
@@ -35,11 +36,12 @@ public class ServiceFactoryTests
         deckRetriever.Should().NotBeNull();
     }
 
-    [Fact]
-    public void GetDeckRetriever_WithEdhrecUrl_ReturnsEdhrecServiceObject()
+    [Theory]
+    [InlineData("https://edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
+    [InlineData("https://www.edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
+    public void GetDeckRetriever_WithEdhrecUrl_ReturnsEdhrecServiceObject(string deckUrl)
     {
         // Arrange
-        string deckUrl = "https://edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA";
         _serviceProviderMock.Setup(x => x.GetService(typeof(IEdhrecService)))
             .Returns(new Mock<IEdhrecService>().Object);
         
@@ -51,11 +53,12 @@ public class ServiceFactoryTests
         deckRetriever.Should().NotBeNull();
     }
 
-    [Fact]
-    public void GetDeckRetriever_WithMoxfieldUrl_ReturnsMoxfieldServiceObject()
+    [Theory]
+    [InlineData("https://moxfield.com/decks/123456/test")]
+    [InlineData("https://www.moxfield.com/decks/123456/test")]
+    public void GetDeckRetriever_WithMoxfieldUrl_ReturnsMoxfieldServiceObject(string deckUrl)
     {
         // Arrange
-        string deckUrl = "https://moxfield.com/decks/123456/test";
         _serviceProviderMock.Setup(x => x.GetService(typeof(IMoxfieldService)))
             .Returns(new Mock<IMoxfieldService>().Object);
 

--- a/UnitTests/Domain/Services/ArchidektServiceTests.cs
+++ b/UnitTests/Domain/Services/ArchidektServiceTests.cs
@@ -23,6 +23,8 @@ public class ArchidektServiceTests
     }
 
     [Theory]
+    [InlineData("archidekt.com/api/decks/123/", 123)]
+    [InlineData("www.archidekt.com/decks/456/", 456)]
     [InlineData("https://archidekt.com/api/decks/123/", 123)]
     [InlineData("https://archidekt.com/decks/456/", 456)]
     public void TryExtractDeckIdFromUrl_ValidUrl_ReturnsTrueAndExtractedDeckId(string url, int expectedDeckId)

--- a/UnitTests/Domain/Services/EdhrecServiceTests.cs
+++ b/UnitTests/Domain/Services/EdhrecServiceTests.cs
@@ -25,6 +25,10 @@ public class EdhrecServiceTests
     }
 
     [Theory]
+    [InlineData("edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA", "deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
+    [InlineData("edhrec.com/commanders/7VNuM_Ce5b3JbQrhfTsObA", "commanders/7VNuM_Ce5b3JbQrhfTsObA")]
+    [InlineData("www.edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA", "deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
+    [InlineData("www.edhrec.com/commanders/7VNuM_Ce5b3JbQrhfTsObA", "commanders/7VNuM_Ce5b3JbQrhfTsObA")]
     [InlineData("https://www.edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA", "deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]
     [InlineData("https://www.edhrec.com/commanders/7VNuM_Ce5b3JbQrhfTsObA", "commanders/7VNuM_Ce5b3JbQrhfTsObA")]
     [InlineData("https://edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA", "deckpreview/7VNuM_Ce5b3JbQrhfTsObA")]

--- a/UnitTests/Domain/Services/MoxfieldServiceTests.cs
+++ b/UnitTests/Domain/Services/MoxfieldServiceTests.cs
@@ -23,16 +23,18 @@ public class MoxfieldServiceTests
     }
 
     [Theory]
+    [InlineData("moxfield.com/decks/123fdgd/", "123fdgd")]
+    [InlineData("www.moxfield.com/decks/123fdgd/", "123fdgd")]
     [InlineData("https://moxfield.com/decks/123fdgd/", "123fdgd")]
     [InlineData("https://www.moxfield.com/decks/123fdgd/", "123fdgd")]
-    public void TryExtractDeckIdFromUrl_ValidUrl_ReturnsTrueAndExtractedDeckId(string url, string expectedDeckId)
+    public void TryExtractDeckIdFromUrl_ValidUrl_ReturnsTrueAndExtractedRelatedPath(string url, string expectedId)
     {
         // Act
         bool result = _service.TryExtractDeckIdFromUrl(url, out string deckId);
 
         // Assert
         result.Should().BeTrue();
-        deckId.Should().Be(expectedDeckId);
+        deckId.Should().Be(expectedId);
     }
 
     [Theory]
@@ -42,11 +44,11 @@ public class MoxfieldServiceTests
     public void TryExtractDeckIdFromUrl_InvalidUrl_ReturnsFalse(string url)
     {
         // Act
-        bool result = _service.TryExtractDeckIdFromUrl(url, out string deckId);
+        bool result = _service.TryExtractDeckIdFromUrl(url, out string relatedPath);
 
         // Assert
         result.Should().BeFalse();
-        deckId.Should().Be(string.Empty);
+        relatedPath.Should().Be(string.Empty);
     }
 
     [Fact]


### PR DESCRIPTION
[Fix issue with www at the beginning of the URL](https://github.com/Furrman/MagicProxyPrinter/pull/21/commits/d756823f5b9f55be3b96afa9c9ebccc3eb78848c)

[Add support for link without scheme prefix](https://github.com/Furrman/MagicProxyPrinter/pull/21/commits/6bb7f3dc9cf7b993e0cded858cff6f874c8f8adc)