### PR TITLE
Restrict long urls that will point to wrong address for link using webscrapper

### DIFF
--- a/Domain/Services/EdhrecService.cs
+++ b/Domain/Services/EdhrecService.cs
@@ -118,7 +118,7 @@ public class EdhrecService(IEdhrecClient edhrecClient,
     {
         relativePath = string.Empty;
 
-        string pattern = @"^(https?:\/\/)?(www\.)?edhrec\.com/(?<relativePath>(commanders|deckpreview)/.+)$";
+        string pattern = @"^(https?:\/\/)?(www\.)?edhrec\.com/(?<relativePath>(commanders|deckpreview)/[^/]+/?)$";
         Regex regex = new(pattern);
 
         Match match = regex.Match(url);

--- a/Domain/Services/GoldfishService.cs
+++ b/Domain/Services/GoldfishService.cs
@@ -89,7 +89,7 @@ public class GoldfishService(IGoldfishClient goldfishClient,
     {
         relativePath = string.Empty;
 
-        const string pattern = @"^(https://)?(www\.)?mtggoldfish\.com/(?<relativePath>(deck|archetype)/.+)$";
+        const string pattern = @"^(https://)?(www\.)?mtggoldfish\.com/(?<relativePath>(deck|archetype)/[^/]+/?)$";
         Regex regex = new(pattern);
 
         Match match = regex.Match(url);

--- a/UnitTests/Domain/Factories/ServiceFactoryTests.cs
+++ b/UnitTests/Domain/Factories/ServiceFactoryTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Moq;
 
 using Domain.Factories;
@@ -35,7 +34,7 @@ public class ServiceFactoryTests
 
         // Assert
         _serviceProviderMock.Verify(x => x.GetService(typeof(IArchidektService)), Times.Once);
-        deckRetriever.Should().NotBeNull();
+        Assert.NotNull(deckRetriever);
     }
 
     [Theory]
@@ -54,7 +53,7 @@ public class ServiceFactoryTests
 
         // Assert
         _serviceProviderMock.Verify(x => x.GetService(typeof(IEdhrecService)), Times.Once);
-        deckRetriever.Should().NotBeNull();
+        Assert.NotNull(deckRetriever);
     }
 
     [Theory]
@@ -103,6 +102,6 @@ public class ServiceFactoryTests
         var deckRetriever = _serviceFactory.GetDeckBuildService(deckUrl);
 
         // Assert
-        deckRetriever.Should().BeNull();
+        Assert.Null(deckRetriever);
     }
 }

--- a/UnitTests/Domain/IO/CardListFileParserTests.cs
+++ b/UnitTests/Domain/IO/CardListFileParserTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.IO;
@@ -32,9 +31,9 @@ public class CardListFileParserTest
         var result = _parser.GetDeckFromFile(filePath);
 
         // Assert
-        result.Should().NotBeNull();
-        result.Name.Should().Be("file");
-        result.Cards.Should().BeEmpty();
+        Assert.NotNull(result);
+        Assert.Equal("file", result.Name);
+        Assert.Empty(result.Cards);
     }
 
     [Fact]
@@ -53,11 +52,11 @@ public class CardListFileParserTest
 
         // Assert
         var cardA = result.Cards[0];
-        cardA.Name.Should().Be("Card A");
-        cardA.Quantity.Should().Be(1);
-        cardA.ExpansionCode.Should().BeNull();
-        cardA.Foil.Should().BeFalse();
-        cardA.Etched.Should().BeFalse();
+        Assert.Equal("Card A", cardA.Name);
+        Assert.Equal(1, cardA.Quantity);
+        Assert.Null(cardA.ExpansionCode);
+        Assert.False(cardA.Foil);
+        Assert.False(cardA.Etched);
     }
 
     [Fact]
@@ -76,11 +75,11 @@ public class CardListFileParserTest
 
         // Assert
         var cardB = result.Cards[0];
-        cardB.Name.Should().Be("Card B");
-        cardB.Quantity.Should().Be(2);
-        cardB.ExpansionCode.Should().BeNull();
-        cardB.Foil.Should().BeFalse();
-        cardB.Etched.Should().BeFalse();
+        Assert.Equal("Card B", cardB.Name);
+        Assert.Equal(2, cardB.Quantity);
+        Assert.Null(cardB.ExpansionCode);
+        Assert.False(cardB.Foil);
+        Assert.False(cardB.Etched);
     }
 
     [Fact]
@@ -99,11 +98,11 @@ public class CardListFileParserTest
 
         // Assert
         var cardC = result.Cards[0];
-        cardC.Name.Should().Be("Card C");
-        cardC.Quantity.Should().Be(1);
-        cardC.ExpansionCode.Should().Be("EXP");
-        cardC.Foil.Should().BeFalse();
-        cardC.Etched.Should().BeFalse();
+        Assert.Equal("Card C", cardC.Name);
+        Assert.Equal(1, cardC.Quantity);
+        Assert.Equal("EXP", cardC.ExpansionCode);
+        Assert.False(cardC.Foil);
+        Assert.False(cardC.Etched);
     }
 
     [Fact]
@@ -122,11 +121,11 @@ public class CardListFileParserTest
 
         // Assert
         var cardD = result.Cards[0];
-        cardD.Name.Should().Be("Card D");
-        cardD.Quantity.Should().Be(1);
-        cardD.ExpansionCode.Should().BeNull();
-        cardD.Foil.Should().BeTrue();
-        cardD.Etched.Should().BeFalse();
+        Assert.Equal("Card D", cardD.Name);
+        Assert.Equal(1, cardD.Quantity);
+        Assert.Null(cardD.ExpansionCode);
+        Assert.True(cardD.Foil);
+        Assert.False(cardD.Etched);
     }
 
     [Fact]
@@ -145,11 +144,11 @@ public class CardListFileParserTest
 
         // Assert
         var cardE = result.Cards[0];
-        cardE.Name.Should().Be("Card E");
-        cardE.Quantity.Should().Be(1);
-        cardE.ExpansionCode.Should().BeNull();
-        cardE.Foil.Should().BeFalse();
-        cardE.Etched.Should().BeTrue();
+        Assert.Equal("Card E", cardE.Name);
+        Assert.Equal(1, cardE.Quantity);
+        Assert.Null(cardE.ExpansionCode);
+        Assert.False(cardE.Foil);
+        Assert.True(cardE.Etched);
     }
 
     [Fact]
@@ -171,37 +170,38 @@ public class CardListFileParserTest
 
         // Act
         var result = parser.GetDeckFromFile(filePath);
-
+        
         // Assert
-        result.Cards.Count.Should().Be(4);
+        Assert.Equal(4, result.Cards.Count);
 
         var cardF = result.Cards[0];
-        cardF.Name.Should().Be("Card F");
-        cardF.Quantity.Should().Be(2);
-        cardF.ExpansionCode.Should().BeNull();
-        cardF.Foil.Should().BeFalse();
-        cardF.Etched.Should().BeFalse();
+        Assert.Equal("Card F", cardF.Name);
+        Assert.Equal(2, cardF.Quantity);
+        Assert.Null(cardF.ExpansionCode);
+        Assert.False(cardF.Foil);
+        Assert.False(cardF.Etched);
 
         // Assert Card G
         var cardG = result.Cards[1];
-        cardG.Name.Should().Be("Card G");
-        cardG.Quantity.Should().Be(1);
-        cardG.ExpansionCode.Should().Be("EXP");
-        cardG.Foil.Should().BeFalse();
-        cardG.Etched.Should().BeFalse();
+        Assert.Equal("Card G", cardG.Name);
+        Assert.Equal(1, cardG.Quantity);
+        Assert.Equal("EXP", cardG.ExpansionCode);
+        Assert.False(cardG.Foil);
+        Assert.False(cardG.Etched);
 
         // Assert Card H
         var cardH = result.Cards[2];
-        cardH.Name.Should().Be("Card H");
-        cardH.Quantity.Should().Be(3);
-        cardH.ExpansionCode.Should().BeNull();
+        Assert.Equal("Card H", cardH.Name);
+        Assert.Equal(3, cardH.Quantity);
+        Assert.Null(cardH.ExpansionCode);
 
         // Assert Card I
         var cardI = result.Cards[3];
-        cardI.Name.Should().Be("Card I");
-        cardI.Quantity.Should().Be(1);
-        cardI.ExpansionCode.Should().BeNull();
-        cardI.Foil.Should().BeFalse();
-        cardI.Etched.Should().BeTrue();
+        Assert.Equal("Card I", cardI.Name);
+        Assert.Equal(1, cardI.Quantity);
+        Assert.Null(cardI.ExpansionCode);
+        Assert.False(cardI.Foil);
+        Assert.True(cardI.Etched);
+
     }
 }

--- a/UnitTests/Domain/MagicProxyPrinterTests.cs
+++ b/UnitTests/Domain/MagicProxyPrinterTests.cs
@@ -1,11 +1,9 @@
-using FluentAssertions;
 using Moq;
 
 using Domain;
 using Domain.IO;
 using Domain.Services;
 using Domain.Models.DTO;
-using Domain.Factories;
 using Domain.Strategies;
 
 namespace UnitTests.Domain;
@@ -89,9 +87,9 @@ public class MagicProxyPrinterTests
             => x.GenerateWord(It.IsAny<DeckDetailsDTO>(), It.IsAny<string>(), 
                 It.IsAny<string>(), saveImages), Times.Once);
     }
-
+    
     [Fact]
-    public void GenerateWord_WithInvalidArguments_ThrowsArgumentException()
+    public async Task GenerateWord_WithInvalidArguments_ThrowsArgumentException()
     {
         // Arrange
         string? deckUrl = null;
@@ -103,12 +101,11 @@ public class MagicProxyPrinterTests
         bool printAllTokens = true;
         bool saveImages = true;
 
-        // Act
-        Func<Task> act = async () => await _proxyPrinter.GenerateWord(deckUrl, inputFilePath, outputPath, 
-            outputFileName, languageCode, tokenCopies, printAllTokens, saveImages);
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () => 
+            await _proxyPrinter.GenerateWord(deckUrl, inputFilePath, outputPath, 
+                outputFileName, languageCode, tokenCopies, printAllTokens, saveImages));
         
-        // Assert
-        act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("Wrong input parameters to download deck.");
+        Assert.Equal("Wrong input parameters to download deck.", exception.Message);
     }
 }

--- a/UnitTests/Domain/Services/ArchidektServiceTests.cs
+++ b/UnitTests/Domain/Services/ArchidektServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Clients;
@@ -33,8 +32,8 @@ public class ArchidektServiceTests
         bool result = _service.TryExtractDeckIdFromUrl(url, out int deckId);
 
         // Assert
-        result.Should().BeTrue();
-        deckId.Should().Be(expectedDeckId);
+        Assert.True(result);
+        Assert.Equal(expectedDeckId, deckId);
     }
 
     [Theory]
@@ -47,8 +46,8 @@ public class ArchidektServiceTests
         bool result = _service.TryExtractDeckIdFromUrl(url, out int deckId);
 
         // Assert
-        result.Should().BeFalse();
-        deckId.Should().Be(0);
+        Assert.False(result);
+        Assert.Equal(0, deckId);
     }
 
     [Fact]
@@ -68,13 +67,13 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("Test Deck");
-        result.Cards.Should().HaveCount(2);
-        result.Cards[0].Name.Should().Be("Card 1");
-        result.Cards[0].Quantity.Should().Be(2);
-        result.Cards[1].Name.Should().Be("Card 2");
-        result.Cards[1].Quantity.Should().Be(3);
+        Assert.NotNull(result);
+        Assert.Equal("Test Deck", result!.Name);
+        Assert.Equal(2, result.Cards.Count);
+        Assert.Equal("Card 1", result.Cards[0].Name);
+        Assert.Equal(2, result.Cards[0].Quantity);
+        Assert.Equal("Card 2", result.Cards[1].Name);
+        Assert.Equal(3, result.Cards[1].Quantity);
     }
 
     [Fact]
@@ -89,7 +88,7 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
     [Fact]
@@ -105,8 +104,8 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards.Should().BeEmpty();
+        Assert.NotNull(result);
+        Assert.Empty(result!.Cards);
     }
 
     [Fact]
@@ -122,8 +121,8 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards.Should().BeEmpty();
+        Assert.NotNull(result);
+        Assert.Empty(result!.Cards);
     }
     
     [Fact]
@@ -139,9 +138,9 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards.Should().HaveCount(1);
-        result.Cards[0].Art.Should().BeTrue();
+        Assert.NotNull(result);
+        Assert.Single(result!.Cards);
+        Assert.True(result.Cards[0].Art);
     }
 
     [Fact]
@@ -157,9 +156,9 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards.Should().HaveCount(1);
-        result.Cards[0].Etched.Should().BeTrue();
+        Assert.NotNull(result);
+        Assert.Single(result!.Cards);
+        Assert.True(result.Cards[0].Etched);
     }
 
     [Fact]
@@ -175,8 +174,8 @@ public class ArchidektServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards.Should().HaveCount(1);
-        result.Cards[0].Foil.Should().BeTrue();
+        Assert.NotNull(result);
+        Assert.Single(result!.Cards);
+        Assert.True(result.Cards[0].Foil);
     }
 }

--- a/UnitTests/Domain/Services/EdhrecServiceTests.cs
+++ b/UnitTests/Domain/Services/EdhrecServiceTests.cs
@@ -46,8 +46,10 @@ public class EdhrecServiceTests
     [Theory]
     [InlineData("https://edhrec.com/commanders")]
     [InlineData("https://edhrec.com/commanders/")]
+    [InlineData("https://edhrec.com/commanders/123fdgd/123fdgd")]
     [InlineData("https://edhrec.com/deckpreview")]
     [InlineData("https://edhrec.com/deckpreview/")]
+    [InlineData("https://edhrec.com/deckpreview/123fdgd/123fdgd")]
     [InlineData("https://edhrec.com/")]
     public void TryExtractRelativePath_InvalidUrl_ReturnsFalse(string url)
     {

--- a/UnitTests/Domain/Services/EdhrecServiceTests.cs
+++ b/UnitTests/Domain/Services/EdhrecServiceTests.cs
@@ -1,11 +1,8 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Clients;
-using Domain.Factories;
-using Domain.Models.DTO;
 using Domain.Services;
 
 namespace UnitTests.Domain.Services;
@@ -39,8 +36,8 @@ public class EdhrecServiceTests
         bool result = _service.TryExtractRelativePath(url, out string deckId);
 
         // Assert
-        result.Should().BeTrue();
-        deckId.Should().Be(expectedDeckId);
+        Assert.True(result);
+        Assert.Equal(expectedDeckId, deckId);
     }
 
     [Theory]
@@ -57,8 +54,8 @@ public class EdhrecServiceTests
         bool result = _service.TryExtractRelativePath(url, out string deckId);
 
         // Assert
-        result.Should().BeFalse();
-        deckId.Should().Be(string.Empty);
+        Assert.False(result);
+        Assert.Equal(string.Empty, deckId);
     }
 
     [Fact]
@@ -72,7 +69,7 @@ public class EdhrecServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
     
     [Fact]
@@ -82,23 +79,23 @@ public class EdhrecServiceTests
         string deckUrl = "https://edhrec.com/deckpreview/7VNuM_Ce5b3JbQrhfTsObA";
         _edhrecClientMock.Setup(x => x.GetCardsInHtml(It.IsAny<string>())).ReturnsAsync("""
             <html lang="en">
-            	<body>
-            		<div id="__next">
-            			<main class="Main_main__Kkd1U">
-            				<div class="Leaderboard_container__2JclS">
-            					<div class="Leaderboard_leaderboard__5X5XE">
-            						<div class="lazyload-wrapper h-100">
-            							<div class="lazyload-placeholder"/>
-            						</div>
-            					</div>
-            					<div class="mvLeaderboard"/>
-            				</div>
-            				<div class="d-flex flex-grow-1 p-3 pe-lg-0">
-            					<div class="d-flex w-100">
-            						<div class="Main_left__B9nka">
-            							<div class="Container_container__A7FAx">
-            								<div class="CoolHeader_container__MASgl card shadow-sm">
-            									<h3 class="m-2">Deck with Commodore Guff</h3>
+                <body>
+                    <div id="__next">
+                        <main class="Main_main__Kkd1U">
+                            <div class="Leaderboard_container__2JclS">
+                                <div class="Leaderboard_leaderboard__5X5XE">
+                                    <div class="lazyload-wrapper h-100">
+                                        <div class="lazyload-placeholder"/>
+                                    </div>
+                                </div>
+                                <div class="mvLeaderboard"/>
+                            </div>
+                            <div class="d-flex flex-grow-1 p-3 pe-lg-0">
+                                <div class="d-flex w-100">
+                                    <div class="Main_left__B9nka">
+                                        <div class="Container_container__A7FAx">
+                                            <div class="CoolHeader_container__MASgl card shadow-sm">
+                                                <h3 class="m-2">Deck with Commodore Guff</h3>
                                             </div>
                                         </div>
                                     </div>
@@ -114,8 +111,8 @@ public class EdhrecServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("Deck with Commodore Guff");
+        Assert.NotNull(result);
+        Assert.Equal("Deck with Commodore Guff", result!.Name);
     }
 
     [Fact]
@@ -174,11 +171,11 @@ public class EdhrecServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards[0].Should().NotBeNull();
-        result.Cards[0].Name.Should().Be("Arena Rector");
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Cards[0]);
+        Assert.Equal("Arena Rector", result.Cards[0].Name);
         // Quantity in EDHRec should be 1 by default
-        result.Cards[0].Quantity.Should().Be(1);
+        Assert.Equal(1, result.Cards[0].Quantity);
     }
     
     [Fact]
@@ -220,8 +217,8 @@ public class EdhrecServiceTests
         var (link, html) = await _service.GetOriginalDeckLink(deckUrl);
 
         // Assert
-        link.Should().NotBeNull();
-        link.Should().Be("https://archidekt.com/decks/9146588?utm_source=edhrec&utm_medium=deck_summary");
+        Assert.NotNull(link);
+        Assert.Equal("https://archidekt.com/decks/9146588?utm_source=edhrec&utm_medium=deck_summary", link);
     }
     
     [Fact]
@@ -263,7 +260,7 @@ public class EdhrecServiceTests
         var (link, html) = await _service.GetOriginalDeckLink(deckUrl);
 
         // Assert
-        link.Should().NotBeNull();
-        link.Should().Be("https://moxfield.com/decks/nZ2YLfU3J0KpYpsMsYHIRQ?utm_source=edhrec&utm_medium=deck_summary");
+        Assert.NotNull(link);
+        Assert.Equal("https://moxfield.com/decks/nZ2YLfU3J0KpYpsMsYHIRQ?utm_source=edhrec&utm_medium=deck_summary", link);
     }
 }

--- a/UnitTests/Domain/Services/GoldfishServiceTests.cs
+++ b/UnitTests/Domain/Services/GoldfishServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Clients;
@@ -33,8 +32,8 @@ public class GoldfishServiceTests
         bool result = _service.TryExtractRelativePath(url, out string relativePath);
 
         // Assert
-        result.Should().BeTrue();
-        relativePath.Should().Be(expectedPath);
+        Assert.True(result);
+        Assert.Equal(expectedPath, relativePath);
     }
 
     [Theory]
@@ -48,8 +47,8 @@ public class GoldfishServiceTests
         bool result = _service.TryExtractRelativePath(url, out string relatedPath);
 
         // Assert
-        result.Should().BeFalse();
-        relatedPath.Should().Be(string.Empty);
+        Assert.False(result);
+        Assert.Equal(string.Empty, relatedPath);
     }
 
     [Fact]
@@ -64,7 +63,7 @@ public class GoldfishServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
     
     [Fact]
@@ -85,8 +84,8 @@ public class GoldfishServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("My First Deck");
+        Assert.NotNull(result);
+        Assert.Equal("My First Deck", result!.Name);
     }
 
     [Fact]
@@ -108,10 +107,10 @@ public class GoldfishServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards[0].Should().NotBeNull();
-        result.Cards[0].Id.Should().BeNull();
-        result.Cards[0].Name.Should().Be("Omniscience");
-        result.Cards[0].Quantity.Should().Be(4);
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Cards[0]);
+        Assert.Null(result.Cards[0].Id);
+        Assert.Equal("Omniscience", result.Cards[0].Name);
+        Assert.Equal(4, result.Cards[0].Quantity);
     }
 }

--- a/UnitTests/Domain/Services/GoldfishServiceTests.cs
+++ b/UnitTests/Domain/Services/GoldfishServiceTests.cs
@@ -40,6 +40,7 @@ public class GoldfishServiceTests
     [Theory]
     [InlineData("https://mtggoldfish.com/deck")]
     [InlineData("https://mtggoldfish.com/deck/")]
+    [InlineData("https://mtggoldfish.com/deck/123fdgd/123fdgd")]
     [InlineData("https://mtggoldfish.com/")]
     public void TryExtractRelativePath_InvalidUrl_ReturnsFalse(string url)
     {

--- a/UnitTests/Domain/Services/LanguageServiceTests.cs
+++ b/UnitTests/Domain/Services/LanguageServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Services;
@@ -35,7 +34,7 @@ public class LanguageServiceTests
         bool result = _service.IsValidLanguage(languageCode);
 
         // Assert
-        result.Should().BeTrue();
+        Assert.True(result);
     }
 
     [Theory]
@@ -49,7 +48,7 @@ public class LanguageServiceTests
         bool result = _service.IsValidLanguage(languageCode);
 
         // Assert
-        result.Should().BeFalse();
+        Assert.False(result);
     }
 
     [Fact]
@@ -59,7 +58,7 @@ public class LanguageServiceTests
         bool result = _service.IsValidLanguage(null);
 
         // Assert
-        result.Should().BeFalse();
+        Assert.False(result);
     }
 
     [Fact]
@@ -72,6 +71,6 @@ public class LanguageServiceTests
         string availableLanguages = _service.AvailableLanguages;
 
         // Assert
-        availableLanguages.Should().Be(expectedLanguages);
+        Assert.Equal(expectedLanguages, availableLanguages);
     }
 }

--- a/UnitTests/Domain/Services/MoxfieldServiceTests.cs
+++ b/UnitTests/Domain/Services/MoxfieldServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Clients;
@@ -33,8 +32,8 @@ public class MoxfieldServiceTests
         bool result = _service.TryExtractDeckIdFromUrl(url, out string deckId);
 
         // Assert
-        result.Should().BeTrue();
-        deckId.Should().Be(expectedId);
+        Assert.True(result);
+        Assert.Equal(expectedId, deckId);
     }
 
     [Theory]
@@ -47,8 +46,8 @@ public class MoxfieldServiceTests
         bool result = _service.TryExtractDeckIdFromUrl(url, out string relatedPath);
 
         // Assert
-        result.Should().BeFalse();
-        relatedPath.Should().Be(string.Empty);
+        Assert.False(result);
+        Assert.Equal(string.Empty, relatedPath);
     }
 
     [Fact]
@@ -62,7 +61,7 @@ public class MoxfieldServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
     
     [Fact]
@@ -79,8 +78,8 @@ public class MoxfieldServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("Test Deck");
+        Assert.NotNull(result);
+        Assert.Equal("Test Deck", result!.Name);
     }
 
     [Fact]
@@ -116,10 +115,10 @@ public class MoxfieldServiceTests
         var result = await _service.RetrieveDeckFromWeb(deckUrl);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Cards[0].Should().NotBeNull();
-        result.Cards[0].Id.Should().Be(cardId);
-        result.Cards[0].Name.Should().Be("Test Card 1");
-        result.Cards[0].Quantity.Should().Be(2);
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Cards[0]);
+        Assert.Equal(cardId, result.Cards[0].Id);
+        Assert.Equal("Test Card 1", result.Cards[0].Name);
+        Assert.Equal(2, result.Cards[0].Quantity);
     }
 }

--- a/UnitTests/Domain/Services/ScryfallServiceTests.cs
+++ b/UnitTests/Domain/Services/ScryfallServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 
-using FluentAssertions;
 using Moq;
 
 using Domain.Clients;
@@ -91,10 +90,10 @@ public class ScryfallServiceTests
     public async Task UpdateCardImageLinks_WhenCardsAreProvided_ShouldSetCardImageLinks()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" }
-        ];
+        };
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
@@ -107,7 +106,7 @@ public class ScryfallServiceTests
 
         // Assert
         _scryfallClientMock.Verify(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
-        cards[0].CardSides.First().ImageUrl.Should().Be("https://example.com/card1.jpg");
+        Assert.Equal("https://example.com/card1.jpg", cards[0].CardSides.First().ImageUrl);
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public class ScryfallServiceTests
 
         // Assert
         _scryfallClientMock.Verify(api => api.GetCard(It.IsAny<Guid>()), Times.Once);
-        cards[0].CardSides.First().ImageUrl.Should().Be("https://example.com/card1.jpg");
+        Assert.Equal("https://example.com/card1.jpg", cards[0].CardSides.First().ImageUrl);
     }
 
     [Fact]
@@ -147,31 +146,33 @@ public class ScryfallServiceTests
 
         // Assert
         _scryfallClientMock.Verify(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
-        cards[0].CardSides.Should().BeEmpty();
+        Assert.Empty(cards[0].CardSides);
     }
 
     [Fact]
     public async Task UpdateCardImageLinks_WhenCardIsDualSide_ShouldUpdateBothPagesCardImageLinks()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" }
-        ];
+        };
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
-                    new CardDataDTO 
-                    { 
-                        Name = "Card 1", 
-                        CardFaces =
-                        [
-                            new CardFaceDTO () { Name = "Front", ImageUriData = new CardImageUriDTO() { Large = "https://example.com/card1.jpg" } },
-                            new CardFaceDTO () { Name = "Back", ImageUriData = new CardImageUriDTO() { Large = "https://example.com/card1-back.jpg" } }
-                        ]}
-                ]
+            Data =
+            [
+                new CardDataDTO 
+                { 
+                    Name = "Card 1", 
+                    CardFaces =
+                    [
+                        new CardFaceDTO () { Name = "Front", ImageUriData = new CardImageUriDTO() { Large = "https://example.com/card1.jpg" } },
+                        new CardFaceDTO () { Name = "Back", ImageUriData = new CardImageUriDTO() { Large = "https://example.com/card1-back.jpg" } }
+                    ]
+                }
+            ]
             });
 
         // Act
@@ -179,22 +180,24 @@ public class ScryfallServiceTests
 
         // Assert
         _scryfallClientMock.Verify(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
-        cards[0].CardSides.Should().NotBeEmpty().And.HaveCount(2);
+        Assert.NotEmpty(cards[0].CardSides);
+        Assert.Equal(2, cards[0].CardSides.Count);
     }
 
     [Fact]
     public async Task UpdateCardImageLinks_WhenCardIsArt_ShouldUpdateFirstPageCardImageLink()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1", Art = true }
-        ];
+        };
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO 
                     { 
                         Name = "Card 1", 
@@ -211,24 +214,25 @@ public class ScryfallServiceTests
 
         // Assert
         _scryfallClientMock.Verify(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
-        cards[0].CardSides.Should().NotBeEmpty()
-            .And.HaveCount(1)
-            .And.ContainSingle(cs => cs.ImageUrl == "https://example.com/card1.jpg");
+        Assert.NotEmpty(cards[0].CardSides);
+        Assert.Single(cards[0].CardSides);
+        Assert.Equal("https://example.com/card1.jpg", cards[0].CardSides.First().ImageUrl);
     }
 
     [Fact]
     public async Task UpdateCardImageLinks_WhenTokenCopyNumberSpecified_ShouldAddTokens()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" }
-        ];
+        };
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -241,8 +245,9 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards, tokenCopies: 1);
 
         // Assert
-        cards[0].Tokens.Should().HaveCount(1)
-            .And.ContainSingle(cs => cs.Uri == "https://example.com/card1-token.jpg" && cs.Name == "Card 1 Token");
+        Assert.Single(cards[0].Tokens);
+        Assert.Equal("https://example.com/card1-token.jpg", cards[0].Tokens.First().Uri);
+        Assert.Equal("Card 1 Token", cards[0].Tokens.First().Name);
     }
 
     [Fact]
@@ -257,7 +262,8 @@ public class ScryfallServiceTests
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -270,23 +276,24 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards);
 
         // Assert
-        cards[0].Tokens.Should().BeEmpty();
+        Assert.Empty(cards[0].Tokens);
     }
 
     [Fact]
     public async Task UpdateCardImageLinks_WhenTokenCopyNumberSpecified_ShouldAddTokensSpecifiedNumberOfTimesToOtherCardsForPrinting()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" }
-        ];
+        };
         var tokenId = Guid.NewGuid();
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -301,23 +308,27 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards, tokenCopies: 3);
 
         // Assert
-        cards.Should().Contain(c => c.Name == "Card 1 Token" && c.Quantity == 3 && c.CardSides.First().ImageUrl == "https://example.com/card1-token.jpg");
+        var tokenCard = cards.FirstOrDefault(c => c.Name == "Card 1 Token");
+        Assert.NotNull(tokenCard);
+        Assert.Equal(3, tokenCard.Quantity);
+        Assert.Equal("https://example.com/card1-token.jpg", tokenCard.CardSides.First().ImageUrl);
     }
 
     [Fact]
     public async Task UpdateCardImageLinks_WhenTokenCopyNumberNotSpecified_ShouldNotAddAnyTokensToOtherCardsForPrinting()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" }
-        ];
+        };
         var tokenId = Guid.NewGuid();
 
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -332,23 +343,24 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards);
 
         // Assert
-        cards.Should().NotContain(c => c.Name == "Card 1 Token" && c.Quantity == 3 && c.CardSides.First().ImageUrl == "https://example.com/card1-token.jpg");
+        Assert.DoesNotContain(cards, c => c.Name == "Card 1 Token" && c.Quantity == 3 && c.CardSides.First().ImageUrl == "https://example.com/card1-token.jpg");
     }
     
     [Fact]
     public async Task UpdateCardImageLinks_WhenTokenCopyNumberSpecifiedAndGroupingTokensSet_ShouldNotAddTheSameTokenMoreTimesThanSpecified()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" },
             new() { Name = "Card 2" }
-        ];
+        };
         var tokenId = Guid.NewGuid();
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -368,23 +380,26 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards, tokenCopies: 1, groupTokens: true);
 
         // Assert
-        cards.Should().ContainSingle(card => card.Name == "Token" && card.Quantity == 1);
+        var tokenCard = cards.FirstOrDefault(card => card.Name == "Token");
+        Assert.NotNull(tokenCard);
+        Assert.Equal(1, tokenCard.Quantity);
     }
     
     [Fact]
     public async Task UpdateCardImageLinks_WhenTokenCopyNumberSpecifiedAndGroupingTokensUnset_ShouldAddTheSameTokenMoreTimesThanSpecified()
     {
         // Arrange
-        List<CardEntryDTO> cards =
-        [
+        List<CardEntryDTO> cards = new List<CardEntryDTO>
+        {
             new() { Name = "Card 1" },
             new() { Name = "Card 2" }
-        ];
+        };
         var tokenId = Guid.NewGuid();
         _scryfallClientMock.Setup(api => api.SearchCard(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new CardSearchDTO()
             {
-                Data = [
+                Data =
+                [
                     new CardDataDTO
                     {
                         Name = "Card 1", 
@@ -404,6 +419,6 @@ public class ScryfallServiceTests
         await _service.UpdateCardImageLinks(cards, tokenCopies: 1, groupTokens: false);
 
         // Assert
-        cards.Where(card => card.Name == "Token").Should().HaveCount(2);
+        Assert.Equal(2, cards.Count(card => card.Name == "Token"));
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.7.1" />


### PR DESCRIPTION
[Limit urls in Goldfish and EDHRec](https://github.com/Furrman/MagicProxyPrinter/commit/4454bb8afc63f9d90c166a095b53d6561f410dae)


[Remove FluentAssertion package from UnitTests](https://github.com/Furrman/MagicProxyPrinter/commit/0e68acc81e4a4dc3fb2fe6915739b17d98262864)